### PR TITLE
Refactor the install

### DIFF
--- a/install
+++ b/install
@@ -124,7 +124,7 @@ k3s_install_service()
 {
   info "Installing k3s service with the following parameters:" "${INSTALL_K3S_EXEC} ${INTERNAL_INSTALL_K3S_EXEC}"
   curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" INSTALL_K3S_EXEC="${INSTALL_K3S_EXEC} ${INTERNAL_INSTALL_K3S_EXEC}"  sh -s -
-  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+   export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 }
 
 k3s_install_service_gpu()
@@ -145,7 +145,11 @@ default_installation(){
 
 
 manage_plugin(){
- info "plugin" $1
+ PLUGIN=$1
+ PLUGIN="${PLUGIN:2}"
+ info "plugin" $PLUGIN
+ 
+ curl -sfL https://raw.githubusercontent.com/kf5i/k3ai-plugins/main/$PLUGIN/install | bash -s -
 }
 
 

--- a/install
+++ b/install
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+#########################################
+### K3ai (keɪ3ai)
+### https://github.com/kf5i/k3ai
+### Alessandro Festa @bringyourownai
+### Gabriele Santomaggio @gsantomaggio
+######################################### 
+
 info()
 {
     echo '[INFO] ' "$@"
@@ -41,86 +49,127 @@ while [ : ]
   done
 }
 
+kubeflow_install_pipelines(){
+    info "Installing pipelines crd"
+    export PIPELINE_VERSION=1.0.1
+    kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
+    kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
+    sleep_cursor &
+    info "Installing pipelines manifests"
+    kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref=$PIPELINE_VERSION"
 
-if [ $1 = "--gpu" ]
-  then   
-    info "Install Pipelines with GPU support, docker as runtime"
-    curl -sfL https://get.k3s.io | sh -s - --docker --kubelet-arg="feature-gates=DevicePlugins=true" --write-kubeconfig-mode 644
-    #### GPU Support
-    kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.7.0/nvidia-device-plugin.yml
-  else  
-    info "Install Pipelines without GPU support, containerd as runtime"
-    curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644
-fi
+    waiting_pod_array=("k8s-app=kube-dns;kube-system" 
+                       "k8s-app=metrics-server;kube-system"
+                       "app=traefik;kube-system"  
+                       "app=minio;kubeflow"
+                       "app=mysql;kubeflow"
+                       "app=cache-server;kubeflow"
+                       "app=ml-pipeline-persistenceagent;kubeflow"
+                       "component=metadata-grpc-server;kubeflow"
+                       "app=ml-pipeline-ui;kubeflow")
 
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-
-info "Installing pipelines crd"
-export PIPELINE_VERSION=1.0.1
-kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
-kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
-sleep_cursor &
-info "Installing pipelines manifests"
-kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref=$PIPELINE_VERSION"
-
-waiting_pod_array=("k8s-app=kube-dns;kube-system" 
-                   "k8s-app=metrics-server;kube-system"
-                   "app=traefik;kube-system"  
-                   "app=minio;kubeflow"
-                   "app=mysql;kubeflow"
-                   "app=cache-server;kubeflow"
-                   "app=ml-pipeline-persistenceagent;kubeflow"
-                   "component=metadata-grpc-server;kubeflow"
-                   "app=ml-pipeline-ui;kubeflow")
-
-for i in "${waiting_pod_array[@]}"; do 
-  echo "$i"; 
-  IFS=';' read -ra VALUES <<< "$i"
-    wait "${VALUES[0]}" "${VALUES[1]}"
-done
+    for i in "${waiting_pod_array[@]}"; do 
+      echo "$i"; 
+      IFS=';' read -ra VALUES <<< "$i"
+        wait "${VALUES[0]}" "${VALUES[1]}"
+    done
 
 
 
-info "Kubeflow pipelines ready!!"
+    info "Kubeflow pipelines ready!!"
 
-info "Defining the ingress"
-sleep_cursor
+    info "Defining the ingress"
+    sleep_cursor
 
-kubectl apply -f - << EOF
-  apiVersion: networking.k8s.io/v1beta1
-  kind: IngressClass
-  metadata: 
-    name: traefik-lb
-  spec: 
-    controller: traefik.io/ingress-controller
+    kubectl apply -f - << EOF
+      apiVersion: networking.k8s.io/v1beta1
+      kind: IngressClass
+      metadata: 
+        name: traefik-lb
+      spec: 
+        controller: traefik.io/ingress-controller
 EOF
 
-kubectl apply -f - << EOF
-  apiVersion: "networking.k8s.io/v1beta1"
-  kind: "Ingress"
-  metadata:
-    name: "example-ingress"
-    namespace: kubeflow
-    annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: /$2
-      
-  spec:
-    ingressClassName: "traefik-lb"
-    rules:
-    - http:
-        paths:
-        - path: "/"
-          backend:
-            serviceName: "ml-pipeline-ui"
-            servicePort: 80
+    kubectl apply -f - << EOF
+      apiVersion: "networking.k8s.io/v1beta1"
+      kind: "Ingress"
+      metadata:
+        name: "pipeline-ingress"
+        namespace: kubeflow
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: /$2
+          
+      spec:
+        ingressClassName: "traefik-lb"
+        rules:
+        - http:
+            paths:
+            - path: "/"
+              backend:
+                serviceName: "ml-pipeline-ui"
+                servicePort: 80
 EOF
 
 sleep_cursor
+}
 
-info "K3s AI ready!!"
+##################
+INTERNAL_OPTIONS=""
 
-info "To use kubectl: export KUBECONFIG=/etc/rancher/k3s/k3s.yaml"
-info "or you can use k3s kubectl "
+
+k3s_install_service()
+{
+  info "Installing k3s service with the following parameters:" "${INSTALL_K3S_EXEC} ${INTERNAL_OPTIONS}"
+  curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" INSTALL_K3S_EXEC="${INSTALL_K3S_EXEC} ${INTERNAL_OPTIONS}"  sh -s -
+  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+}
+
+k3s_install_gpu()
+{
+  info "Installing the GPU Support on docker"
+  INTERNAL_OPTIONS="--docker"  
+  k3s_install_service 
+  #### GPU Support
+  kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.7.0/nvidia-device-plugin.yml
+}
+
+
+default_installation(){
+    info "Installing pipelines"
+    k3s_install_service
+    kubeflow_install_pipelines
+}
+
+main() {
+    ### DEFAULT == --pipelines
+    if [[ "$#" -eq 0 ]]; then
+     default_installation
+    fi  
+    while [[ "$#" -ne 0 ]]; do
+      case "$1" in
+      "--gpu")
+          shift 1
+          k3s_install_gpu
+          kubeflow_install_pipelines
+          ;;
+      "--pipelines")
+          shift 1
+          echo "pipelines"
+          default_installation
+          ;;
+      *)
+          echo "No Valid parameters"
+          ### todo implement the help
+          exit 1
+          ;;
+      esac
+    done
+}
+
+main "$@"
+
+
+info "K3ai setup finished"
 info "k3s-uninstall.sh to uninstall"
 
 IP=$(kubectl get service/traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' -n kube-system)

--- a/install
+++ b/install
@@ -147,8 +147,8 @@ default_installation(){
 manage_plugin(){
  PLUGIN=$1
  PLUGIN="${PLUGIN:2}"
- info "plugin" $PLUGIN
- 
+ info "Installing plugin: " $PLUGIN
+ info "URL:" https://raw.githubusercontent.com/kf5i/k3ai-plugins/main/$PLUGIN/install
  curl -sfL https://raw.githubusercontent.com/kf5i/k3ai-plugins/main/$PLUGIN/install | bash -s -
 }
 

--- a/install
+++ b/install
@@ -111,23 +111,26 @@ EOF
 EOF
 
 sleep_cursor
+
+IP=$(kubectl get service/traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' -n kube-system)
+info "pipelines UI: http://"$IP 
 }
 
 ##################
-INTERNAL_OPTIONS=""
+INTERNAL_INSTALL_K3S_EXEC=""
 
 
 k3s_install_service()
 {
-  info "Installing k3s service with the following parameters:" "${INSTALL_K3S_EXEC} ${INTERNAL_OPTIONS}"
-  curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" INSTALL_K3S_EXEC="${INSTALL_K3S_EXEC} ${INTERNAL_OPTIONS}"  sh -s -
+  info "Installing k3s service with the following parameters:" "${INSTALL_K3S_EXEC} ${INTERNAL_INSTALL_K3S_EXEC}"
+  curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" INSTALL_K3S_EXEC="${INSTALL_K3S_EXEC} ${INTERNAL_INSTALL_K3S_EXEC}"  sh -s -
   export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 }
 
-k3s_install_gpu()
+k3s_install_service_gpu()
 {
   info "Installing the GPU Support on docker"
-  INTERNAL_OPTIONS="--docker"  
+  INTERNAL_INSTALL_K3S_EXEC="--docker"  
   k3s_install_service 
   #### GPU Support
   kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.7.0/nvidia-device-plugin.yml
@@ -140,27 +143,65 @@ default_installation(){
     kubeflow_install_pipelines
 }
 
+
+manage_plugin(){
+ info "plugin" $1
+}
+
+
+manage() {
+    ### DEFAULT == --cpu and --pipelines
+  #  if [[ "$#" -eq 0 ]]; then
+  #   kubeflow_install_pipelines
+  #  fi  
+    while [[ "$#" -ne 0 ]]; do
+      case "$1" in
+      "--pipelines")          
+          kubeflow_install_pipelines  
+          shift 1
+          ;;
+      --plugin*)
+          info "Installing plugin:" "$1"
+          manage_plugin  "$1"
+          shift 1
+          ;;
+      *)
+          shift 1
+          ;;
+      esac
+    done
+}
+
+
+
+
 main() {
-    ### DEFAULT == --pipelines
+    ### DEFAULT == --cpu and --pipelines
     if [[ "$#" -eq 0 ]]; then
      default_installation
     fi  
+    OR="$@"
     while [[ "$#" -ne 0 ]]; do
       case "$1" in
       "--gpu")
+          k3s_install_service_gpu
+          manage $OR
           shift 1
-          k3s_install_gpu
-          kubeflow_install_pipelines
           ;;
-      "--pipelines")
+      "--cpu")
+          info "Installing the CPU Support"
+          k3s_install_service
+          manage $OR
           shift 1
-          echo "pipelines"
-          default_installation
           ;;
+      "--skipk3s")
+          info "Skip Installation Server"
+          manage $OR
+          shift 1
+          ;;
+
       *)
-          echo "No Valid parameters"
-          ### todo implement the help
-          exit 1
+          shift 1
           ;;
       esac
     done
@@ -172,6 +213,4 @@ main "$@"
 info "K3ai setup finished"
 info "k3s-uninstall.sh to uninstall"
 
-IP=$(kubectl get service/traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' -n kube-system)
-info "pipelines UI: http://"$IP 
 


### PR DESCRIPTION
Fixes https://github.com/kf5i/k3ai/issues/11.


With this PR we are changing the setup installation:
https://github.com/kf5i/k3ai/blob/refactor_11/install

We can use the k3s parameters installation:
https://github.com/kf5i/k3ai/blob/refactor_11/install#L126

Skip the server installation: 
https://github.com/kf5i/k3ai/blob/refactor_11/install#L197

open the doors for the plugins:
https://github.com/kf5i/k3ai/blob/refactor_11/install#L163 

So you can:
```
install ### by default installs the pipelines in cpu
```
or
```
install --gpu --pipelines
```
or
``` 
install --cpu --pipeline
```
or 
```
INSTALL_K3S_EXEC="--no-deploy traefik" ./install --gpu
```
with curl:
```
 curl -sfL https://raw.githubusercontent.com/kf5i/k3ai/refactor_11/install |INSTALL_K3S_EXEC="--no-deploy traefik"  bash -s --  --gpu
```