### PR TITLE
Check the platform through uname comparison

### DIFF
--- a/install
+++ b/install
@@ -202,9 +202,13 @@ main() {
     done
 }
 
-main "$@"
 
+if [[ "${OSTYPE/-*}" != "linux" ]]; then
+  info "K3ai  works only on Linux. The new version: https://github.com/kf5i/k3ai-core will be cross-platform :)!"
+else
+  main "$@"
 
-info "K3ai setup finished"
-info $MESSAGE
-info "Check the nodes status using: k3s kubectl get node"
+  info "K3ai setup finished"
+  info $MESSAGE
+  info "Check the nodes status using: k3s kubectl get node"
+fi


### PR DESCRIPTION
Currently the install script doesn't check for the platform, and yesterday evening I discovered at my own expense that k3ai only runs on Linux. So I thought to add a `uname` preliminary check 🙂 